### PR TITLE
Some updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+local.*
+scripts

--- a/README.md
+++ b/README.md
@@ -33,7 +33,22 @@ Options:
 
 * `-a` Check analysis
 * `-d` Check deprecations (default)
-* `-t` Module type {core, custom, contrib (default)}
+* `-t` Module type {core, custom, profile, contrib (default)}
+* `-p` Profile name for multi-sites if using a profile type module
+* `-v` Verbose output
+
+Assumptions:
+
+The `-p profile_name` and `-t profile` arguments assume that your profile and modules follow this directory structure:
+```
+/var/www/DOCROOT/profiles/custom/PROFILE_DIR/modules/MODULE_NAME
+```
+The command `fin drupal-check my_profile_module -a -t profile -p my_profile_name` will look for your module in:
+```
+/var/www/DOCROOT/profiles/custom/my_profile_name/modules/my_profile_module
+```
+
+In the event that this does not match your path, you can use a local.drupal-check file. For best results, copy and rename the `example.local.drupal-check` file and add your path to the `CUSTOM` variable.
 
 Examples:
 
@@ -59,4 +74,16 @@ Examples:
 
   ```shell
   fin drupal-check address -a
+  ```
+
+* Check a custom, profile specific module for analysis:
+
+  ```shell
+  fin drupal-check my_profile_module -a -t profile -p my_profile_name
+  ```
+
+* Check a custom module for analysis with verbose output:
+
+  ```shell
+  fin drupal-check my_custom_module -a -t custom -v
   ```

--- a/drupal-check
+++ b/drupal-check
@@ -67,7 +67,5 @@ else
     MODULE_PATH="/var/www/${DOCROOT}/modules/${MODULE_TYPE}/${MODULE_NAME}"
 fi
 
-echo ${MODULE_PATH}
-echo ${CUSTOM}
 # Execute script.
 #fin exec php ${SCRIPTS_DIR}/drupal-check ${CHECK_OPTS[@]} ${MODULE_PATH}

--- a/drupal-check
+++ b/drupal-check
@@ -68,4 +68,4 @@ else
 fi
 
 # Execute script.
-#fin exec php ${SCRIPTS_DIR}/drupal-check ${CHECK_OPTS[@]} ${MODULE_PATH}
+fin exec php ${SCRIPTS_DIR}/drupal-check ${CHECK_OPTS[@]} ${MODULE_PATH}

--- a/drupal-check
+++ b/drupal-check
@@ -13,16 +13,19 @@ VERSION="1.0"
 ## Options
 ##    -a        Check analysis
 ##    -d        Check deprecations (default)
-##    -t        Module type {core, custom, contrib (default)}
+##    -t        Module type {core, custom, profile, contrib (default)}
 
 # Default variables.
 SCRIPTS_DIR="/var/www/.docksal/addons/drupal-check/scripts"
 MODULE_TYPE="contrib"
 CHECK_OPTS=()
+PROFILE_DIR=""
+SCRIPT_ARG=""
+
+# Import local settings
+[[ -f local.drupal-check ]] && source local.drupal-check || CUSTOM=false
 
 # Check if arguments are included.
-
-
 # Get the module name.
 if [[ -z "$1" ]]; then
     echo "Please provide a module name."
@@ -32,7 +35,7 @@ else
     shift
 fi
 
-while getopts 'adt:' opt; do
+while getopts 'adt:p:v' opt; do
     case ${opt} in
         a )
             CHECK_OPTS+=("-a")
@@ -43,15 +46,28 @@ while getopts 'adt:' opt; do
         t )
             MODULE_TYPE=${OPTARG}
         ;;
+        p )
+            PROFILE_DIR=${OPTARG}
+        ;;
+        v )
+            CHECK_OPTS+=("-vvv")
     esac
 done
 
 # Generate the module path.
 if [[ "${MODULE_TYPE}" = "core" ]]; then
     MODULE_PATH="/var/www/${DOCROOT}/${MODULE_TYPE}/modules/${MODULE_NAME}"
+elif [[ "${MODULE_TYPE}" = "profile" ]]; then
+  if ! [[ "${CUSTOM}" = false ]]; then
+    MODULE_PATH="${CUSTOM}"
+  else
+    MODULE_PATH="/var/www/${DOCROOT}/profiles/custom/${PROFILE_DIR}/modules/${MODULE_NAME}"
+  fi
 else
     MODULE_PATH="/var/www/${DOCROOT}/modules/${MODULE_TYPE}/${MODULE_NAME}"
 fi
 
+echo ${MODULE_PATH}
+echo ${CUSTOM}
 # Execute script.
-fin exec php ${SCRIPTS_DIR}/drupal-check ${CHECK_OPTS[@]} ${MODULE_PATH}
+#fin exec php ${SCRIPTS_DIR}/drupal-check ${CHECK_OPTS[@]} ${MODULE_PATH}

--- a/example.local.drupal-check
+++ b/example.local.drupal-check
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 
-CUSTOM="some/custom/path"
+## This is where your custom path goes.
+## Variables:
+## DOCROOT - The docroot of your project. In most cases this will be 'docroot'.
+## PROFILE_DIR - The directory of your profile.
+## MODULE_NAME - The name of the module to be evaluated.
+## The custom path MUST match the format of your profile module path or you will get errors.
+
+CUSTOM="/var/www/${DOCROOT}/profiles/custom/${PROFILE_DIR}/modules/${MODULE_NAME}"

--- a/example.local.drupal-check
+++ b/example.local.drupal-check
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+CUSTOM="some/custom/path"


### PR DESCRIPTION
Some quick updates to help things run smoother:

1. Adding the `-p PROFILENAME` flag to select a profile
1. Adding `profile` to the module type list.  This will tell drupal-check that it is a custom module
1. Adding the `-v` flag that will pass along `-vvv` to drupal-check and give you very, very verbose output.
1. Adding an option to set custom module paths for profiles via a local.drupal-check file. Example file included.
1. Updating the README to reflect changes.