### PR TITLE
Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Download or clone the drupal-check addon and place it into your .docksal/addons directory.
 
+This will work regardless of whether your project uses the the Composer based `mglaman/drupal-check` or not.  If you are not using Composer, this addon will install the script from Github for you.
+
 ```shell
 cd .docksal/addons
 git clone https://github.com/cbarrettgenuine/drupal-check.git

--- a/drupal-check
+++ b/drupal-check
@@ -17,14 +17,20 @@ VERSION="1.0.0-beta"
 ##    -v        Verbose output.
 
 # Default variables.
-SCRIPTS_DIR="/var/www/.docksal/addons/drupal-check/scripts"
+ROOT_DIR="/var/www/"
+SCRIPTS_DIR="${ROOT_DIR}.docksal/addons/drupal-check/scripts/drupal-check.phar"
+COMPOSER_DIR="${ROOT_DIR}/vendor/bin/drupal-check"
 MODULE_TYPE="contrib"
 CHECK_OPTS=()
 PROFILE_DIR=""
 SCRIPT_ARG=""
+COMPOSER="local"
 
 # Import local settings
 [[ -f local.drupal-check ]] && source local.drupal-check || CUSTOM=false
+[[ -f "${COMPOSER_DIR}/drupal-check" ]] && [[ -x "${COMPOSER_DIR}/drupal-check" ]] || COMPOSER=false
+
+echo $COMPOSER
 
 # Check if arguments are included.
 # Get the module name.
@@ -69,4 +75,8 @@ else
 fi
 
 # Execute script.
-fin exec php ${SCRIPTS_DIR}/drupal-check.phar ${CHECK_OPTS[@]} ${MODULE_PATH}
+if [[ $COMPOSER = false ]]; then
+  fin exec php ${SCRIPTS_DIR}/drupal-check.phar ${CHECK_OPTS[@]} ${MODULE_PATH}
+else
+  fin exec .COMPOSER_DIR="${ROOT_DIR}/vendor/bin/drupal-check" ${CHECK_OPTS[@]} ${MODULE_PATH}
+fi

--- a/drupal-check
+++ b/drupal-check
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="1.0.0-beta"
+VERSION="1.0.1-beta"
 
 ## Check Drupal code for deprecations and discover bugs via static analysis.
 ##
@@ -19,7 +19,7 @@ VERSION="1.0.0-beta"
 # Default variables.
 ROOT_DIR="/var/www/"
 SCRIPTS_DIR="${ROOT_DIR}.docksal/addons/drupal-check/scripts/drupal-check.phar"
-COMPOSER_DIR="${ROOT_DIR}/vendor/bin/drupal-check"
+COMPOSER_DIR="${PROJECT_ROOT}/vendor/bin/drupal-check"
 MODULE_TYPE="contrib"
 CHECK_OPTS=()
 PROFILE_DIR=""
@@ -28,8 +28,11 @@ COMPOSER="local"
 
 # Import local settings
 [[ -f local.drupal-check ]] && source local.drupal-check || CUSTOM=false
-[[ -f "${COMPOSER_DIR}/drupal-check" ]] && [[ -x "${COMPOSER_DIR}/drupal-check" ]] || COMPOSER=false
+if [[ ! -f "${COMPOSER_DIR}" ]]; then
+  COMPOSER=false
+fi
 
+echo $COMPOSER_DIR
 echo $COMPOSER
 
 # Check if arguments are included.
@@ -78,5 +81,5 @@ fi
 if [[ $COMPOSER = false ]]; then
   fin exec php ${SCRIPTS_DIR}/drupal-check.phar ${CHECK_OPTS[@]} ${MODULE_PATH}
 else
-  fin exec .COMPOSER_DIR="${ROOT_DIR}/vendor/bin/drupal-check" ${CHECK_OPTS[@]} ${MODULE_PATH}
+  fin exec ./vendor/bin/drupal-check ${CHECK_OPTS[@]} ${MODULE_PATH}
 fi

--- a/drupal-check
+++ b/drupal-check
@@ -32,9 +32,6 @@ if [[ ! -f "${COMPOSER_DIR}" ]]; then
   COMPOSER=false
 fi
 
-echo $COMPOSER_DIR
-echo $COMPOSER
-
 # Check if arguments are included.
 # Get the module name.
 if [[ -z "$1" ]]; then

--- a/drupal-check.post-install
+++ b/drupal-check.post-install
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 SCRIPTS_DIR="${PROJECT_ROOT}/.docksal/addons/drupal-check/scripts"
+COMPOSER_DIR="${ROOT_DIR}/vendor/bin/drupal-check"
 
-wget -O ${SCRIPTS_DIR}/drupal-check.phar https://github.com/mglaman/drupal-check/releases/latest/download/drupal-check.phar
+if [[ ! -f $COMPOSER_DIR ]]; then
+  wget -O ${SCRIPTS_DIR}/drupal-check.phar https://github.com/mglaman/drupal-check/releases/latest/download/drupal-check.phar
 
-chmod +x ${SCRIPTS_DIR}/drupal-check.phar
+  chmod +x ${SCRIPTS_DIR}/drupal-check.phar
+fi

--- a/example.local.drupal-check
+++ b/example.local.drupal-check
@@ -7,4 +7,16 @@
 ## MODULE_NAME - The name of the module to be evaluated.
 ## The custom path MUST match the format of your profile module path or you will get errors.
 
+## Any of the following can be changed and will overwrite the variables in
+## the main script.
+# ROOT_DIR="/var/www/"
+# SCRIPTS_DIR="${ROOT_DIR}.docksal/addons/drupal-check/scripts/drupal-check.phar"
+# COMPOSER_DIR="${PROJECT_ROOT}/vendor/bin/drupal-check"
+# MODULE_TYPE="contrib"
+# CHECK_OPTS=()
+# PROFILE_DIR=""
+# SCRIPT_ARG=""
+# COMPOSER="local"
+
+
 CUSTOM="/var/www/${DOCROOT}/profiles/custom/${PROFILE_DIR}/modules/${MODULE_NAME}"


### PR DESCRIPTION
Updates README.md

Checks for composer package `mglaman/drupal-check` and uses that instead of downloading the .phar from mglaman's repo.

Adds more configurable variables.